### PR TITLE
fix: typo of the flag `-noinit` in RequireImportTutorial.v

### DIFF
--- a/src/RequireImportTutorial.v
+++ b/src/RequireImportTutorial.v
@@ -68,7 +68,7 @@
     be [Require]d in order to make its logical and computational content
     available in the current file.
 
-    If not stated otherwise (with the [-no-init] command-line flag), Coq's
+    If not stated otherwise (with the [-noinit] command-line flag), Coq's
     initial state is populated by a dozen library files called the [Prelude]
     (the interested reader can consult its
     #<a href="https://github.com/coq/coq/blob/master/theories/Init/Prelude.v">source code</a>#).


### PR DESCRIPTION
I found a minor typographical error of a command line flag.
c.f. https://rocq-prover.org/doc/v8.20/refman/practical-tools/coq-commands.html

Thanks for the coqtokyo study group.