### PR TITLE
make the use of eqn: for inspect patterns compatible with destruct

### DIFF
--- a/src/Tutorial_Equations_wf.v
+++ b/src/Tutorial_Equations_wf.v
@@ -516,7 +516,7 @@ Instance wfR : WellFounded R := wf_R h.
 
 Definition inspect {A} (a : A) : {b | a = b} := exist _ a eq_refl.
 
-Notation "x 'eqn:' p" := (exist _ x p) (only parsing, at level 20).
+Notation "x 'eqn' ':' p" := (exist _ x p) (only parsing, at level 20).
 
 (** Even though we want to start a computation at 0, to define our function
     by well-founded recursion we need to start at a generic point [m : nat],


### PR DESCRIPTION
This is probably a temporary fix, as the modification in Notation will probably be integrated in the next release of Coq-Equation, as [discussed on zulip](https://rocq-prover.zulipchat.com/#narrow/channel/237659-Equations-devs-.26-users/topic/Problem.20with.20the.20inspect.20pattern/near/513545802))